### PR TITLE
Change migration script location to a package resource

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -131,7 +131,6 @@
         nixosModules = {
           default = import modules/default.nix {
             overlay = arbeitszeitapp.overlays.default;
-            arbeitszeitapp_repo = arbeitszeitapp;
           };
         };
       };

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,6 +1,5 @@
 {
   overlay,
-  arbeitszeitapp_repo,
 }:
 {
   config,
@@ -52,8 +51,7 @@ let
   '';
   alembicFile = pkgs.writeText "alembic.ini" ''
     [alembic]
-    script_location = ${arbeitszeitapp_repo}/arbeitszeit_flask/migrations
-    prepend_sys_path = ${arbeitszeitapp_repo}
+    script_location = arbeitszeit_flask:migrations
     version_path_separator = os
 
     [loggers]
@@ -130,6 +128,7 @@ let
         p.flask-wtf
         p.python-dateutil
         p.psycopg2
+        p.arbeitszeitapp
       ]))
     ];
     text = ''


### PR DESCRIPTION
This approach follows the guideline mentioned in the alembic documentation that for packaged applications, the script location "can also be specified as a package resource, in which case resource_filename() is used to find the file."