### PR TITLE
Update dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4,15 +4,15 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "flask-profiler": "flask-profiler",
-        "nixos-24-05": "nixos-24-05",
+        "nixos-24-11": "nixos-24-11",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1741264254,
-        "narHash": "sha256-nYtD7pyMzdylg7Ba8v8JGL/OK24wb5PDcjbH46orUPA=",
+        "lastModified": 1741868525,
+        "narHash": "sha256-3XRvsvwVDm52AgwWukMgKWNmLyypXXWFYBl9p8mg6Xw=",
         "owner": "ida-arbeitszeit",
         "repo": "arbeitszeitapp",
-        "rev": "a5be83611c22e0c9dd11259e9d252e22de7a97a6",
+        "rev": "af3f471e79bec18826dee677a47713e97c2445b7",
         "type": "github"
       },
       "original": {
@@ -94,18 +94,18 @@
         "type": "github"
       }
     },
-    "nixos-24-05": {
+    "nixos-24-11": {
       "locked": {
-        "lastModified": 1733384649,
-        "narHash": "sha256-K5DJ2LpPqht7K76bsxetI+YHhGGRyVteTPRQaIIKJpw=",
+        "lastModified": 1741724370,
+        "narHash": "sha256-WsD+8uodhl58jzKKcPH4jH9dLTLFWZpVmGq4W1XDVF4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "190c31a89e5eec80dd6604d7f9e5af3802a58a13",
+        "rev": "95600680c021743fd87b3e2fe13be7c290e1cac4",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -128,11 +128,11 @@
     },
     "nixpkgs-24-11": {
       "locked": {
-        "lastModified": 1741048562,
-        "narHash": "sha256-W4YZ3fvWZiFYYyd900kh8P8wU6DHSiwaH0j4+fai1Sk=",
+        "lastModified": 1741724370,
+        "narHash": "sha256-WsD+8uodhl58jzKKcPH4jH9dLTLFWZpVmGq4W1XDVF4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6af28b834daca767a7ef99f8a7defa957d0ade6f",
+        "rev": "95600680c021743fd87b3e2fe13be7c290e1cac4",
         "type": "github"
       },
       "original": {
@@ -144,11 +144,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1741246872,
-        "narHash": "sha256-Q6pMP4a9ed636qilcYX8XUguvKl/0/LGXhHcRI91p0U=",
+        "lastModified": 1741513245,
+        "narHash": "sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "10069ef4cf863633f57238f179a0297de84bd8d3",
+        "rev": "e3e32b642a31e6714ec1b712de8c91a3352ce7e1",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1733376361,
-        "narHash": "sha256-aLJxoTDDSqB+/3orsulE6/qdlX6MzDLIITLZqdgMpqo=",
+        "lastModified": 1741708242,
+        "narHash": "sha256-cNRqdQD4sZpN7JLqxVOze4+WsWTmv2DGH0wNCOVwrWc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "929116e316068c7318c54eb4d827f7d9756d5e9c",
+        "rev": "b62d2a95c72fb068aecd374a7262b37ed92df82b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'arbeitszeitapp':
    'github:ida-arbeitszeit/arbeitszeitapp/a5be83611c22e0c9dd11259e9d252e22de7a97a6?narHash=sha256-nYtD7pyMzdylg7Ba8v8JGL/OK24wb5PDcjbH46orUPA%3D' (2025-03-06)
  → 'github:ida-arbeitszeit/arbeitszeitapp/af3f471e79bec18826dee677a47713e97c2445b7?narHash=sha256-3XRvsvwVDm52AgwWukMgKWNmLyypXXWFYBl9p8mg6Xw%3D' (2025-03-13)
• Removed input 'arbeitszeitapp/nixos-24-05'
• Added input 'arbeitszeitapp/nixos-24-11':
    'github:NixOS/nixpkgs/95600680c021743fd87b3e2fe13be7c290e1cac4?narHash=sha256-WsD%2B8uodhl58jzKKcPH4jH9dLTLFWZpVmGq4W1XDVF4%3D' (2025-03-11)
• Updated input 'arbeitszeitapp/nixpkgs':
    'github:NixOS/nixpkgs/929116e316068c7318c54eb4d827f7d9756d5e9c?narHash=sha256-aLJxoTDDSqB%2B/3orsulE6/qdlX6MzDLIITLZqdgMpqo%3D' (2024-12-05)
  → 'github:NixOS/nixpkgs/b62d2a95c72fb068aecd374a7262b37ed92df82b?narHash=sha256-cNRqdQD4sZpN7JLqxVOze4%2BWsWTmv2DGH0wNCOVwrWc%3D' (2025-03-11)
• Updated input 'nixpkgs-24-11':
    'github:NixOS/nixpkgs/6af28b834daca767a7ef99f8a7defa957d0ade6f?narHash=sha256-W4YZ3fvWZiFYYyd900kh8P8wU6DHSiwaH0j4%2Bfai1Sk%3D' (2025-03-04)
  → 'github:NixOS/nixpkgs/95600680c021743fd87b3e2fe13be7c290e1cac4?narHash=sha256-WsD%2B8uodhl58jzKKcPH4jH9dLTLFWZpVmGq4W1XDVF4%3D' (2025-03-11)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/10069ef4cf863633f57238f179a0297de84bd8d3?narHash=sha256-Q6pMP4a9ed636qilcYX8XUguvKl/0/LGXhHcRI91p0U%3D' (2025-03-06)
  → 'github:NixOS/nixpkgs/e3e32b642a31e6714ec1b712de8c91a3352ce7e1?narHash=sha256-7rTAMNTY1xoBwz0h7ZMtEcd8LELk9R5TzBPoHuhNSCk%3D' (2025-03-09)