### PR TITLE
Upgrade nixpkgs 24-11 -> 25.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4,15 +4,15 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "flask-profiler": "flask-profiler",
-        "nixos-24-11": "nixos-24-11",
+        "nixos-25-05": "nixos-25-05",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1752933819,
-        "narHash": "sha256-XlzxaBppOqtWq5/AfsfH3krMwlILTGIlz5eXylNN2rU=",
+        "lastModified": 1753032013,
+        "narHash": "sha256-usBjmRUiEldEWL+EMeXATF68C3cXr+QqO+I2kJP0IO0=",
         "owner": "ida-arbeitszeit",
         "repo": "arbeitszeitapp",
-        "rev": "e8cfc66e9b9406a7dd212fb3daf14b2566810b16",
+        "rev": "8fa27fdbe07a149c46c99f9a2211c0f8de1d4c06",
         "type": "github"
       },
       "original": {
@@ -94,18 +94,18 @@
         "type": "github"
       }
     },
-    "nixos-24-11": {
+    "nixos-25-05": {
       "locked": {
-        "lastModified": 1751274312,
-        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "lastModified": 1752866191,
+        "narHash": "sha256-NV4S2Lf2hYmZQ3Qf4t/YyyBaJNuxLPyjzvDma0zPp/M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "rev": "f01fe91b0108a7aff99c99f2e9abbc45db0adc2a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -144,11 +144,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1752687322,
-        "narHash": "sha256-RKwfXA4OZROjBTQAl9WOZQFm7L8Bo93FQwSJpAiSRvo=",
+        "lastModified": 1752950548,
+        "narHash": "sha256-NS6BLD0lxOrnCiEOcvQCDVPXafX1/ek1dfJHX1nUIzc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6e987485eb2c77e5dcc5af4e3c70843711ef9251",
+        "rev": "c87b95e25065c028d31a94f06a62927d18763fdf",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1752596105,
-        "narHash": "sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k=",
+        "lastModified": 1752900028,
+        "narHash": "sha256-dPALCtmik9Wr14MGqVXm+OQcv7vhPBXcWNIOThGnB/Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "dab3a6e781554f965bde3def0aa2fda4eb8f1708",
+        "rev": "6b4955211758ba47fac850c040a27f23b9b4008f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -126,18 +126,18 @@
         "type": "github"
       }
     },
-    "nixpkgs-24-11": {
+    "nixpkgs-25-05": {
       "locked": {
-        "lastModified": 1751274312,
-        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "lastModified": 1752866191,
+        "narHash": "sha256-NV4S2Lf2hYmZQ3Qf4t/YyyBaJNuxLPyjzvDma0zPp/M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "rev": "f01fe91b0108a7aff99c99f2e9abbc45db0adc2a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -178,7 +178,7 @@
       "inputs": {
         "arbeitszeitapp": "arbeitszeitapp",
         "flake-utils": "flake-utils_3",
-        "nixpkgs-24-11": "nixpkgs-24-11",
+        "nixpkgs-25-05": "nixpkgs-25-05",
         "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -103,7 +103,7 @@
               }
             ) { };
           testCases = {
-            lauchWebserver = makeSimpleTest tests/launchWebserver.py;
+            launchWebserver = makeSimpleTest tests/launchWebserver.py;
             launchWebserverWithProfiler = makeTestWithProfiling tests/launchWebserver.py;
             testProfiling = makeTestWithProfiling tests/testProfiling.py;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Implements a module for running arbeitszeitapp";
   inputs = {
     arbeitszeitapp.url = "github:ida-arbeitszeit/arbeitszeitapp";
-    nixpkgs-24-11.url = "github:NixOS/nixpkgs/nixos-24.11";
+    nixpkgs-25-05.url = "github:NixOS/nixpkgs/nixos-25.05";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
@@ -10,7 +10,7 @@
   outputs =
     {
       self,
-      nixpkgs-24-11,
+      nixpkgs-25-05,
       nixpkgs-unstable,
       arbeitszeitapp,
       flake-utils,
@@ -80,7 +80,7 @@
               testScript = builtins.readFile testFile;
             };
           nixpkgsVersions = {
-            nixpkgs-24-11 = import nixpkgs-24-11 { inherit system; };
+            nixpkgs-25-05 = import nixpkgs-25-05 { inherit system; };
             nixpkgs-unstable = import nixpkgs-unstable { inherit system; };
           };
           makeTestMatrix =

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,8 @@
               nodes.machine =
                 { config, ... }:
                 {
+                  virtualisation.memorySize = 2048;
+                  virtualisation.diskSize = 1024;
                   imports = [ self.nixosModules.default ];
                   nixpkgs.pkgs = nixpkgs;
                   services.arbeitszeitapp.enable = true;


### PR DESCRIPTION
**flake.lock: Update** 

Flake lock file updates:

• Updated input 'arbeitszeitapp':
    'github:ida-arbeitszeit/arbeitszeitapp/e8cfc66e9b9406a7dd212fb3daf14b2566810b16?narHash=sha256-XlzxaBppOqtWq5/AfsfH3krMwlILTGIlz5eXylNN2rU%3D' (2025-07-19)
  → 'github:ida-arbeitszeit/arbeitszeitapp/8fa27fdbe07a149c46c99f9a2211c0f8de1d4c06?narHash=sha256-usBjmRUiEldEWL%2BEMeXATF68C3cXr%2BQqO%2BI2kJP0IO0%3D' (2025-07-20)
• Removed input 'arbeitszeitapp/nixos-24-11'
• Added input 'arbeitszeitapp/nixos-25-05':
    'github:NixOS/nixpkgs/f01fe91b0108a7aff99c99f2e9abbc45db0adc2a?narHash=sha256-NV4S2Lf2hYmZQ3Qf4t/YyyBaJNuxLPyjzvDma0zPp/M%3D' (2025-07-18)
• Updated input 'arbeitszeitapp/nixpkgs':
    'github:NixOS/nixpkgs/dab3a6e781554f965bde3def0aa2fda4eb8f1708?narHash=sha256-lFNVsu/mHLq3q11MuGkMhUUoSXEdQjCHvpReaGP1S2k%3D' (2025-07-15)
  → 'github:NixOS/nixpkgs/6b4955211758ba47fac850c040a27f23b9b4008f?narHash=sha256-dPALCtmik9Wr14MGqVXm%2BOQcv7vhPBXcWNIOThGnB/Q%3D' (2025-07-19)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/6e987485eb2c77e5dcc5af4e3c70843711ef9251?narHash=sha256-RKwfXA4OZROjBTQAl9WOZQFm7L8Bo93FQwSJpAiSRvo%3D' (2025-07-16)
  → 'github:NixOS/nixpkgs/c87b95e25065c028d31a94f06a62927d18763fdf?narHash=sha256-NS6BLD0lxOrnCiEOcvQCDVPXafX1/ek1dfJHX1nUIzc%3D' (2025-07-19)

**Upgrade nixpkgs 24-11 -> 25.05**

**flake.lock: Update** 

Flake lock file updates:

• Removed input 'nixpkgs-24-11'
• Added input 'nixpkgs-25-05':
    'github:NixOS/nixpkgs/f01fe91b0108a7aff99c99f2e9abbc45db0adc2a?narHash=sha256-NV4S2Lf2hYmZQ3Qf4t/YyyBaJNuxLPyjzvDma0zPp/M%3D' (2025-07-18)

**fix: increase VM resources to prevent segfaults in nixpkgs-25-05 tests** 

The default VM memory (512MB) and disk (512MB) were insufficient for
concurrent test execution with nixpkgs-25-05's larger package footprint.
This caused memory-related segfaults when running `nix flake check` with
multiple tests in parallel.

Increase memory to 2GB and disk to 1GB to accommodate the increased
resource requirements of newer package versions in nixpkgs-25-05.

**Fix typo in testcase name**