### PR TITLE
Update alembic.ini and flake lock file

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1754075738,
-        "narHash": "sha256-mJ9Egm6O76oXxKH3jTqU4UlPpXZpuXudTDhP1SgcTL0=",
+        "lastModified": 1756196570,
+        "narHash": "sha256-pxBX3GnjVwdf6DU1V0JMabkqJfSPPkZzEbb6XWGsD7w=",
         "owner": "ida-arbeitszeit",
         "repo": "arbeitszeitapp",
-        "rev": "a7fb8430ce2b7b3cc8f5d28a49254852b6da9292",
+        "rev": "9ddd8cb78d3273197c06b09968bbd58af60eb0bd",
         "type": "github"
       },
       "original": {
@@ -96,11 +96,11 @@
     },
     "nixos-25-05": {
       "locked": {
-        "lastModified": 1752866191,
-        "narHash": "sha256-NV4S2Lf2hYmZQ3Qf4t/YyyBaJNuxLPyjzvDma0zPp/M=",
+        "lastModified": 1755922037,
+        "narHash": "sha256-wY1+2JPH0ZZC4BQefoZw/k+3+DowFyfOxv17CN/idKs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f01fe91b0108a7aff99c99f2e9abbc45db0adc2a",
+        "rev": "b1b3291469652d5a2edb0becc4ef0246fff97a7c",
         "type": "github"
       },
       "original": {
@@ -128,11 +128,11 @@
     },
     "nixpkgs-25-05": {
       "locked": {
-        "lastModified": 1753749649,
-        "narHash": "sha256-+jkEZxs7bfOKfBIk430K+tK9IvXlwzqQQnppC2ZKFj4=",
+        "lastModified": 1755922037,
+        "narHash": "sha256-wY1+2JPH0ZZC4BQefoZw/k+3+DowFyfOxv17CN/idKs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1f08a4df998e21f4e8be8fb6fbf61d11a1a5076a",
+        "rev": "b1b3291469652d5a2edb0becc4ef0246fff97a7c",
         "type": "github"
       },
       "original": {
@@ -144,11 +144,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1753939845,
-        "narHash": "sha256-K2ViRJfdVGE8tpJejs8Qpvvejks1+A4GQej/lBk5y7I=",
+        "lastModified": 1756125398,
+        "narHash": "sha256-XexyKZpf46cMiO5Vbj+dWSAXOnr285GHsMch8FBoHbc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "94def634a20494ee057c76998843c015909d6311",
+        "rev": "3b9f00d7a7bf68acd4c4abb9d43695afb04e03a5",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1752900028,
-        "narHash": "sha256-dPALCtmik9Wr14MGqVXm+OQcv7vhPBXcWNIOThGnB/Q=",
+        "lastModified": 1756128520,
+        "narHash": "sha256-R94HxJBi+RK1iCm8Y4Q9pdrHZl0GZoDPIaYwjxRNPh4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6b4955211758ba47fac850c040a27f23b9b4008f",
+        "rev": "c53baa6685261e5253a1c355a1b322f82674a824",
         "type": "github"
       },
       "original": {

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -52,7 +52,7 @@ let
   alembicFile = pkgs.writeText "alembic.ini" ''
     [alembic]
     script_location = arbeitszeit_flask:migrations
-    version_path_separator = os
+    path_separator = os
 
     [loggers]
     keys = root,sqlalchemy,alembic


### PR DESCRIPTION
- Update alembic.ini options 

  Replace option version_path_separator with path_separator

- flake.lock: Update 

  Flake lock file updates:

  • Updated input 'arbeitszeitapp':
      'github:ida-arbeitszeit/arbeitszeitapp/a7fb8430ce2b7b3cc8f5d28a49254852b6da9292?narHash=sha256-mJ9Egm6O76oXxKH3jTqU4UlPpXZpuXudTDhP1SgcTL0%3D' (2025-08-01)
    → 'github:ida-arbeitszeit/arbeitszeitapp/9ddd8cb78d3273197c06b09968bbd58af60eb0bd?narHash=sha256-pxBX3GnjVwdf6DU1V0JMabkqJfSPPkZzEbb6XWGsD7w%3D' (2025-08-26)
  • Updated input 'arbeitszeitapp/nixos-25-05':
      'github:NixOS/nixpkgs/f01fe91b0108a7aff99c99f2e9abbc45db0adc2a?narHash=sha256-NV4S2Lf2hYmZQ3Qf4t/YyyBaJNuxLPyjzvDma0zPp/M%3D' (2025-07-18)
    → 'github:NixOS/nixpkgs/b1b3291469652d5a2edb0becc4ef0246fff97a7c?narHash=sha256-wY1%2B2JPH0ZZC4BQefoZw/k%2B3%2BDowFyfOxv17CN/idKs%3D' (2025-08-23)
  • Updated input 'arbeitszeitapp/nixpkgs':
      'github:NixOS/nixpkgs/6b4955211758ba47fac850c040a27f23b9b4008f?narHash=sha256-dPALCtmik9Wr14MGqVXm%2BOQcv7vhPBXcWNIOThGnB/Q%3D' (2025-07-19)
    → 'github:NixOS/nixpkgs/c53baa6685261e5253a1c355a1b322f82674a824?narHash=sha256-R94HxJBi%2BRK1iCm8Y4Q9pdrHZl0GZoDPIaYwjxRNPh4%3D' (2025-08-25)
  • Updated input 'nixpkgs-25-05':
      'github:NixOS/nixpkgs/1f08a4df998e21f4e8be8fb6fbf61d11a1a5076a?narHash=sha256-%2BjkEZxs7bfOKfBIk430K%2BtK9IvXlwzqQQnppC2ZKFj4%3D' (2025-07-29)
    → 'github:NixOS/nixpkgs/b1b3291469652d5a2edb0becc4ef0246fff97a7c?narHash=sha256-wY1%2B2JPH0ZZC4BQefoZw/k%2B3%2BDowFyfOxv17CN/idKs%3D' (2025-08-23)
  • Updated input 'nixpkgs-unstable':
      'github:NixOS/nixpkgs/94def634a20494ee057c76998843c015909d6311?narHash=sha256-K2ViRJfdVGE8tpJejs8Qpvvejks1%2BA4GQej/lBk5y7I%3D' (2025-07-31)
    → 'github:NixOS/nixpkgs/3b9f00d7a7bf68acd4c4abb9d43695afb04e03a5?narHash=sha256-XexyKZpf46cMiO5Vbj%2BdWSAXOnr285GHsMch8FBoHbc%3D' (2025-08-25)