### PR TITLE
Update workers control app and dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -75,11 +75,11 @@
     },
     "nixos-25-11": {
       "locked": {
-        "lastModified": 1766473571,
-        "narHash": "sha256-5G1NDO2PulBx1RoaA6U1YoUDX0qZslpPxv+n5GX6Qto=",
+        "lastModified": 1767480499,
+        "narHash": "sha256-8IQQUorUGiSmFaPnLSo2+T+rjHtiNWc+OAzeHck7N48=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "76701a179d3a98b07653e2b0409847499b2a07d3",
+        "rev": "30a3c519afcf3f99e2c6df3b359aec5692054d92",
         "type": "github"
       },
       "original": {
@@ -107,11 +107,11 @@
     },
     "nixpkgs-25-11": {
       "locked": {
-        "lastModified": 1766736597,
-        "narHash": "sha256-BASnpCLodmgiVn0M1MU2Pqyoz0aHwar/0qLkp7CjvSQ=",
+        "lastModified": 1767480499,
+        "narHash": "sha256-8IQQUorUGiSmFaPnLSo2+T+rjHtiNWc+OAzeHck7N48=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f560ccec6b1116b22e6ed15f4c510997d99d5852",
+        "rev": "30a3c519afcf3f99e2c6df3b359aec5692054d92",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1766651565,
-        "narHash": "sha256-QEhk0eXgyIqTpJ/ehZKg9IKS7EtlWxF3N7DXy42zPfU=",
+        "lastModified": 1767379071,
+        "narHash": "sha256-EgE0pxsrW9jp9YFMkHL9JMXxcqi/OoumPJYwf+Okucw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e2499d5539c16d0d173ba53552a4ff8547f4539",
+        "rev": "fb7944c166a3b630f177938e478f0378e64ce108",
         "type": "github"
       },
       "original": {
@@ -139,11 +139,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1766624085,
-        "narHash": "sha256-ruzNOGQR0HKynAarKRhAYwIZc79IkDqui4ovQmkZPQI=",
+        "lastModified": 1767364772,
+        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b72f284b1be41575c3e36cd777a191c29a7adf6a",
+        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
         "type": "github"
       },
       "original": {
@@ -214,16 +214,16 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1767107038,
-        "narHash": "sha256-wD6UMxMhYgRT7dzZwgkKi/66xLsnQ9OvkevbNeT8pOo=",
+        "lastModified": 1767592849,
+        "narHash": "sha256-lQOQy/CT8NPMzY80UNGMkdohwPo8oG6J8szZBy5t6dU=",
         "owner": "ida-arbeitszeit",
         "repo": "workers-control",
-        "rev": "d2180ec8c92f3e866ba18089e5b3f13f57d8b4c7",
+        "rev": "5b5085131d0ba5bbf53cb59904867731d00b6f03",
         "type": "github"
       },
       "original": {
         "owner": "ida-arbeitszeit",
-        "ref": "v0.1.2",
+        "ref": "v0.1.4",
         "repo": "workers-control",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Implements a module for running workers control app";
   inputs = {
-    workers-control.url = "github:ida-arbeitszeit/workers-control?ref=v0.1.2";
+    workers-control.url = "github:ida-arbeitszeit/workers-control?ref=v0.1.4";
     nixpkgs-25-11.url = "github:NixOS/nixpkgs/nixos-25.11";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";


### PR DESCRIPTION
Update workers control app to v0.1.4

Flake lock file updates:

• Updated input 'nixpkgs-25-11':
    'github:NixOS/nixpkgs/f560ccec6b1116b22e6ed15f4c510997d99d5852?narHash=sha256-BASnpCLodmgiVn0M1MU2Pqyoz0aHwar/0qLkp7CjvSQ%3D' (2025-12-26)
  → 'github:NixOS/nixpkgs/30a3c519afcf3f99e2c6df3b359aec5692054d92?narHash=sha256-8IQQUorUGiSmFaPnLSo2%2BT%2BrjHtiNWc%2BOAzeHck7N48%3D' (2026-01-03)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/3e2499d5539c16d0d173ba53552a4ff8547f4539?narHash=sha256-QEhk0eXgyIqTpJ/ehZKg9IKS7EtlWxF3N7DXy42zPfU%3D' (2025-12-25)
  → 'github:NixOS/nixpkgs/fb7944c166a3b630f177938e478f0378e64ce108?narHash=sha256-EgE0pxsrW9jp9YFMkHL9JMXxcqi/OoumPJYwf%2BOkucw%3D' (2026-01-02)
• Updated input 'workers-control/nixos-25-11':
    'github:NixOS/nixpkgs/76701a179d3a98b07653e2b0409847499b2a07d3?narHash=sha256-5G1NDO2PulBx1RoaA6U1YoUDX0qZslpPxv%2Bn5GX6Qto%3D' (2025-12-23)
  → 'github:NixOS/nixpkgs/30a3c519afcf3f99e2c6df3b359aec5692054d92?narHash=sha256-8IQQUorUGiSmFaPnLSo2%2BT%2BrjHtiNWc%2BOAzeHck7N48%3D' (2026-01-03)
• Updated input 'workers-control/nixpkgs':
    'github:NixOS/nixpkgs/b72f284b1be41575c3e36cd777a191c29a7adf6a?narHash=sha256-ruzNOGQR0HKynAarKRhAYwIZc79IkDqui4ovQmkZPQI%3D' (2025-12-25)
  → 'github:NixOS/nixpkgs/16c7794d0a28b5a37904d55bcca36003b9109aaa?narHash=sha256-fFUnEYMla8b7UKjijLnMe%2BoVFOz6HjijGGNS1l7dYaQ%3D' (2026-01-02)