### PR TITLE
Change deployment to deploy "latest" workers control app

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Workers Control deployment utilities
 
 The `nix flake`_ defined in this repository provides a NixOS
 module. This module allows NixOS administrators to setup a basic
-instance of the workers control app.
+instance of the workers control app (latest).
 
 
 Management commands
@@ -27,8 +27,6 @@ The update process is as follows:
 
 - Make sure that you have checked out the newest version of this
   repository on your local machine.
-- If there is a new version of the workers control app, update the
-  tag name in the workers control flake input in :py:mod:`flake.nix`.
 - Run ``nix flake update --commit-lock-file`` to update all the flake
   inputs
 - Run the tests via ``nix flake check``

--- a/flake.lock
+++ b/flake.lock
@@ -107,11 +107,11 @@
     },
     "nixpkgs-25-11": {
       "locked": {
-        "lastModified": 1767480499,
-        "narHash": "sha256-8IQQUorUGiSmFaPnLSo2+T+rjHtiNWc+OAzeHck7N48=",
+        "lastModified": 1768323494,
+        "narHash": "sha256-yBXJLE6WCtrGo7LKiB6NOt6nisBEEkguC/lq/rP3zRQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "30a3c519afcf3f99e2c6df3b359aec5692054d92",
+        "rev": "2c3e5ec5df46d3aeee2a1da0bfedd74e21f4bf3a",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1767379071,
-        "narHash": "sha256-EgE0pxsrW9jp9YFMkHL9JMXxcqi/OoumPJYwf+Okucw=",
+        "lastModified": 1768564909,
+        "narHash": "sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fb7944c166a3b630f177938e478f0378e64ce108",
+        "rev": "e4bae1bd10c9c57b2cf517953ab70060a828ee6f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -214,16 +214,15 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1767592849,
-        "narHash": "sha256-lQOQy/CT8NPMzY80UNGMkdohwPo8oG6J8szZBy5t6dU=",
+        "lastModified": 1768512989,
+        "narHash": "sha256-D9WNvYHhaS1aramcjs0bhbW2HXssgtqNeDyqYcZlZSE=",
         "owner": "ida-arbeitszeit",
         "repo": "workers-control",
-        "rev": "5b5085131d0ba5bbf53cb59904867731d00b6f03",
+        "rev": "c39dc28452e30f9c7db29835870f82eae9f65445",
         "type": "github"
       },
       "original": {
         "owner": "ida-arbeitszeit",
-        "ref": "v0.1.4",
         "repo": "workers-control",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Implements a module for running workers control app";
   inputs = {
-    workers-control.url = "github:ida-arbeitszeit/workers-control?ref=v0.1.4";
+    workers-control.url = "github:ida-arbeitszeit/workers-control";
     nixpkgs-25-11.url = "github:NixOS/nixpkgs/nixos-25.11";
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";


### PR DESCRIPTION
**Deploy latest, not stable, workers control app** 

Change flake input to use latest 'workers control' version (from the default branch), not stable. The latest versions are well tested and contain the latest changes.