### PR TITLE
Remove usage of unneeded ALEMBIC_CONFIG envvar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,14 +10,10 @@ Management commands
 ====================
 
 The NixOS module provides a management command, `arbeitszeitapp-manage`,
-which can be used by server admins to invite accountants to the app::
+which can be used by server admins to invite accountants to the app
+and provides access to alembic, a tool for database migrations::
 
-  arbeitszeitapp-manage
-
-It provides also access to alembic, a tool for database migrations,
-connected to worker control's database::
-
-  alembic-command --help
+  arbeitszeitapp-manage --help
 
 
 Update dependencies

--- a/flake.lock
+++ b/flake.lock
@@ -107,11 +107,11 @@
     },
     "nixpkgs-25-11": {
       "locked": {
-        "lastModified": 1772465433,
-        "narHash": "sha256-ywy9troNEfpgh0Ee+zaV1UTgU8kYBVKtvPSxh6clYGU=",
+        "lastModified": 1773068389,
+        "narHash": "sha256-vMrm7Pk2hjBRPnCSjhq1pH0bg350Z+pXhqZ9ICiqqCs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c581273b8d5bdf1c6ce7e0a54da9841e6a763913",
+        "rev": "44bae273f9f82d480273bab26f5c50de3724f52f",
         "type": "github"
       },
       "original": {
@@ -123,11 +123,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1772433332,
-        "narHash": "sha256-izhTDFKsg6KeVBxJS9EblGeQ8y+O8eCa6RcW874vxEc=",
+        "lastModified": 1772963539,
+        "narHash": "sha256-9jVDGZnvCckTGdYT53d/EfznygLskyLQXYwJLKMPsZs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cf59864ef8aa2e178cccedbe2c178185b0365705",
+        "rev": "9dcb002ca1690658be4a04645215baea8b95f31d",
         "type": "github"
       },
       "original": {
@@ -214,11 +214,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1772558326,
-        "narHash": "sha256-nfp6O0L5b2xWNE8yAPRDyhmnEvd9TO1fN5+L5vAaeKk=",
+        "lastModified": 1773169079,
+        "narHash": "sha256-Y/eH+l4fwNGma5afX7CRiVh0jArmgdAde3K6xDeeFZU=",
         "owner": "ida-arbeitszeit",
         "repo": "workers-control",
-        "rev": "a9d7eb6946aaef6c6446e1e314816e315bde75b2",
+        "rev": "2c9e1ec62724849143c38705be7b811da3560ef7",
         "type": "github"
       },
       "original": {

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -48,46 +48,6 @@ let
     MAIL_ADMIN = mail_config["MAIL_ADMIN"]
     MAIL_ENCRYPTION_TYPE = "${cfg.emailEncryptionType}"
   '';
-  alembicFile = pkgs.writeText "alembic.ini" ''
-    [alembic]
-    script_location = workers_control.db:migrations
-    path_separator = os
-    sqlalchemy.url = ${databaseUri}
-
-    [loggers]
-    keys = root,sqlalchemy,alembic
-
-    [handlers]
-    keys = console
-
-    [formatters]
-    keys = generic
-
-    [logger_root]
-    level = WARN
-    handlers = console
-    qualname =
-
-    [logger_sqlalchemy]
-    level = WARN
-    handlers =
-    qualname = sqlalchemy.engine
-
-    [logger_alembic]
-    level = INFO
-    handlers =
-    qualname = alembic
-
-    [handler_console]
-    class = StreamHandler
-    args = (sys.stderr,)
-    level = NOTSET
-    formatter = generic
-
-    [formatter_generic]
-    format = %(levelname)-5.5s [%(name)s] %(message)s
-    datefmt = %H:%M:%S
-  '';
   configFile = pkgs.writeText "arbeitszeitapp.cfg" ''
     import secrets
     import json
@@ -115,20 +75,6 @@ let
     ${if cfg.profilingEnabled then profilingConfigSection else ""}
   '';
 
-  alembicCommand = pkgs.writeShellApplication {
-    name = "alembic-command";
-    runtimeInputs = [
-      (pkgs.python3.withPackages (p: [
-        p.alembic
-        p.psycopg2
-        p.workers-control
-      ]))
-    ];
-    text = ''
-      ALEMBIC_CONFIG=${alembicFile} alembic "$@"
-    '';
-  };
-
   manageCommand = pkgs.writeShellApplication {
     name = "arbeitszeitapp-manage";
     runtimeInputs = [
@@ -137,13 +83,13 @@ let
         p.psycopg2
         p.flask
         p.flask-profiler
+        p.alembic
       ]))
     ];
     text = ''
       cd ${stateDirectory}
       FLASK_APP=workers_control.flask.wsgi:app \
       MPLCONFIGDIR=${stateDirectory} \
-      ALEMBIC_CONFIG=${alembicFile} \
       WOCO_CONFIGURATION_PATH=${configFile} \
       flask "$@"
     '';
@@ -213,7 +159,6 @@ in
     nixpkgs.overlays = [ overlay ];
     environment.systemPackages = [
       manageCommand
-      alembicCommand
     ];
     services.postgresql = {
       enable = true;
@@ -244,7 +189,6 @@ in
         type = "emperor";
         vassals.arbeitszeitapp = {
           env = [
-            "ALEMBIC_CONFIG=${alembicFile}"
             "WOCO_CONFIGURATION_PATH=${configFile}"
             "MPLCONFIGDIR=${stateDirectory}"
           ];

--- a/tests/launchWebserver.py
+++ b/tests/launchWebserver.py
@@ -8,7 +8,7 @@ machine.wait_for_open_port(80)
 assert "Workers Control" in machine.succeed("curl -vLf localhost/")
 assert "Workers Control" in machine.succeed("curl -vLf localhost/login-member")
 machine.succeed("curl -vLf localhost/static/main.js")
-machine.succeed("sudo -u arbeitszeitapp alembic-command upgrade head")
+machine.succeed("sudo -u arbeitszeitapp arbeitszeitapp-manage db upgrade head")
 
 # Check if service still works after restarting
 machine.succeed("systemctl restart uwsgi.service")


### PR DESCRIPTION
Instead of using a custom alembic.ini config file, we use the default one that comes bundled with workers control app.